### PR TITLE
fix: add top padding to jobs page

### DIFF
--- a/jobScape/frontend/src/App.css
+++ b/jobScape/frontend/src/App.css
@@ -1362,7 +1362,8 @@ p {
 
 /* Jobs Page Styles */
 .jobs-page {
-  padding: 2rem 0;
+  /* Add top padding to compensate for the fixed navbar so content isn't hidden */
+  padding: 6rem 0 2rem;
   min-height: 100vh;
   background: var(--bg-primary);
 }


### PR DESCRIPTION
## Summary
- ensure Jobs page content isn't hidden behind fixed navbar

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary')*
- `npm install cloudinary jsonwebtoken node-cron express nodemailer mongoose` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cloudinary)*

------
https://chatgpt.com/codex/tasks/task_e_68b3418e84888331b553c76ef6b7ec77