### PR TITLE
fix: center icons in register inputs

### DIFF
--- a/jobScape/frontend/src/App.css
+++ b/jobScape/frontend/src/App.css
@@ -2047,6 +2047,8 @@ p {
 .input-with-icon .input-icon {
   position: absolute;
   left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
   color: var(--text-muted);
   font-size: 1.1rem;
 }


### PR DESCRIPTION
## Summary
- vertically center icons in form inputs to correct misalignment on the register page

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` (root) *(fails: missing modules and unexpected token errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b347e52b48833191333f995ff0ddfa