### PR TITLE
Fix light mode toggle

### DIFF
--- a/jobScape/frontend/src/components/Navbar.jsx
+++ b/jobScape/frontend/src/components/Navbar.jsx
@@ -15,7 +15,7 @@ const Navbar = () => {
   const location = useLocation();
 
   useEffect(() => {
-    document.body.className = theme === "dark" ? "dark" : "";
+    document.body.className = theme === "light" ? "light" : "";
     localStorage.setItem("theme", theme);
   }, [theme]);
 


### PR DESCRIPTION
## Summary
- correctly apply `light` class to body when light theme is enabled
- maintain theme preference in localStorage

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary', etc.)*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b349600e888331b38e0a70600e76ae