### PR TITLE
Add global theme toggle and dynamic Toast container

### DIFF
--- a/jobScape/frontend/src/App.jsx
+++ b/jobScape/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import "./App.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
@@ -17,6 +17,15 @@ import { getUser } from "./store/slices/userSlice";
 
 const App = () => {
   const dispatch = useDispatch();
+  const [theme, setTheme] = useState(localStorage.getItem("theme") || "dark");
+
+  useEffect(() => {
+    document.body.className = theme === "light" ? "light" : "";
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
 
   useEffect(() => {
     dispatch(getUser());
@@ -25,7 +34,7 @@ const App = () => {
   return (
     <>
       <Router>
-        <Navbar />
+        <Navbar theme={theme} toggleTheme={toggleTheme} />
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/jobs" element={<Jobs />} />
@@ -39,7 +48,7 @@ const App = () => {
           <Route path="*" element={<NotFound />} />
         </Routes>
         <Footer />
-        <ToastContainer position="top-right" theme="dark" />
+        <ToastContainer position="top-right" theme={theme} />
       </Router>
     </>
   );

--- a/jobScape/frontend/src/components/Navbar.jsx
+++ b/jobScape/frontend/src/components/Navbar.jsx
@@ -5,19 +5,11 @@ import { GiHamburgerMenu } from "react-icons/gi";
 import { FaSun, FaMoon, FaUserCircle } from "react-icons/fa";
 import { RiLogoutCircleRLine } from "react-icons/ri";
 
-const Navbar = () => {
+const Navbar = ({ theme, toggleTheme }) => {
   const [show, setShow] = useState(false);
-  const [theme, setTheme] = useState(
-    localStorage.getItem("theme") || "dark"
-  );
   const [scrolled, setScrolled] = useState(false);
   const { isAuthenticated, user } = useSelector((state) => state.user);
   const location = useLocation();
-
-  useEffect(() => {
-    document.body.className = theme === "light" ? "light" : "";
-    localStorage.setItem("theme", theme);
-  }, [theme]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -28,9 +20,6 @@ const Navbar = () => {
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
-
-  const toggleTheme = () =>
-    setTheme((prev) => (prev === "light" ? "dark" : "light"));
 
   const isActiveLink = (path) => {
     return location.pathname === path;


### PR DESCRIPTION
## Summary
- centralize theme state in App and persist to localStorage
- pass theme controls to Navbar and update icon toggle
- align ToastContainer theme with current mode

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary', 'jsonwebtoken', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b34be190d48331bd60bd4bec0b6574